### PR TITLE
[detext] Prepare package for PyPi

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,22 @@
+Uploading new releases of DeText to PyPi
+=========
+NOTE: this guide is for DeText owners to publish new versions to PyPi
+
+1. Make sure you have the correct permission to release DeText packages. Only owners and maintainers can upload new releases for DeText. Check more details at https://pypi.org/project/detext/.
+
+2. Create a source distribution by:
+``
+python setup.py sdist
+```
+
+3. Install `twine` for uploading to PyPi
+```
+pip install twine
+```
+
+4. Upload the distribution
+```
+twine upload dist/*
+```
+
+You can verify the release upload at https://pypi.org/manage/project/detext/releases/

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 import setuptools
 setuptools.setup(
     name='detext',
-    version='1.0.1',
+    version='1.0.7',
     package_dir={'': 'src'},
     packages=setuptools.find_packages('src'),
     include_package_data=True,

--- a/src/detext/__init__.py
+++ b/src/detext/__init__.py
@@ -1,0 +1,5 @@
+try:
+    __import__('pkg_resources').declare_namespace(__name__)
+except ImportError:
+    from pkgutil import extend_path
+    __path__ = extend_path(__path__, __name__)


### PR DESCRIPTION
Adding required files for packaging to release to PyPi.
Also added an instruction file on how dev team can release packages at `RELEASING.md`. 