### PR TITLE
import input_fn from outside of train for internal integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@ TEST-*.xml
 __pycache__/
 /*/build
 .DS_Store
+
+gradle/
+gradlew
+gradlew.bat

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -12,6 +12,7 @@ import tensorflow as tf
 import tensorflow_ranking as tfr
 
 from detext.train import train
+from detext.train.data_fn import input_fn
 from detext.utils import misc_utils, logger, executor_utils
 
 
@@ -302,7 +303,7 @@ def main(argv):
     logging.info("***********DeText Training***********")
 
     # Train and evaluate DeText model
-    train.train(hparams)
+    train.train(hparams, input_fn)
 
 
 if __name__ == '__main__':

--- a/src/detext/train/train.py
+++ b/src/detext/train/train.py
@@ -7,17 +7,17 @@ from detext.model.deep_match import DeepMatch
 from detext.model.lambdarank import LambdaRank
 from detext.train import metrics
 from detext.train import optimization, train_helper
-from detext.train.data_fn import input_fn
 from detext.train.loss import compute_softmax_loss, compute_sigmoid_cross_entropy_loss, \
     compute_regularization_penalty
 from detext.utils import vocab_utils, executor_utils
 from detext.utils.best_checkpoint_copier import BestCheckpointCopier
 
 
-def train(hparams):
+def train(hparams, input_fn):
     """
     Main function for train/evaluate DeText ranking model
     :param hparams: hparams
+    :param input_fn: input function to create train/eval specs
     :return:
     """
     eval_log_file = None


### PR DESCRIPTION
Importing the input function `input_fn` from outside of `train` and pass the function to `train.`

This allows for easy incorporation with the internal data function with avro data-- we can directly call `train` with it.

Local testing done.