### PR TITLE
Doc/usr projection

### DIFF
--- a/src/detext/model/rep_model.py
+++ b/src/detext/model/rep_model.py
@@ -150,12 +150,34 @@ class RepModel(object):
             num_sim_ftrs = ftr_size * num_doc_fields
             return num_sim_ftrs, sim_ftrs
 
+        # If use_doc_projection, then the n doc fields are projected to 1 vector space
+        if hparams.use_doc_projection:
+            doc_ftrs = tf.reshape(doc_ftrs, shape=[batch_size, max_group_size, 1, ftr_size * num_doc_fields])
+            doc_ftrs = tf.layers.dense(doc_ftrs,
+                                       ftr_size,
+                                       use_bias=True,
+                                       activation=tf.tanh,
+                                       name="doc_ftrs_projection_layer")  # [batch_size, max_group_size, ftr_size]
+            doc_ftrs = tf.identity(doc_ftrs, name='doc_ftrs_projection')
+            num_doc_fields = 1
+
         # Compute interaction between user text/query and document text
         num_usr_fields = 0
         tot_usr_ftrs = []
         if usr_ftrs is not None:
+            # If use_usr_projection, then the n usr fields are projected to 1 vector space
+            if hparams.use_usr_projection:
+                usr_ftrs = tf.reshape(usr_ftrs, shape=[batch_size, 1, ftr_size * self.num_usr_fields])
+                usr_ftrs = tf.layers.dense(usr_ftrs,
+                                           ftr_size,
+                                           use_bias=True,
+                                           activation=tf.tanh,
+                                           name="usr_ftrs_projection_layer")  # [batch_size, max_group_size, ftr_size]
+                usr_ftrs = tf.identity(usr_ftrs, name='usr_ftrs_projection')
+                num_usr_fields = 1
+            else:
+                num_usr_fields += self.num_usr_fields
             tot_usr_ftrs.append(usr_ftrs)
-            num_usr_fields += self.num_usr_fields
 
         # Treat query as one user field and append it to user field
         if query_ftrs is not None:

--- a/src/detext/model/rep_model.py
+++ b/src/detext/model/rep_model.py
@@ -157,7 +157,7 @@ class RepModel(object):
                                        ftr_size,
                                        use_bias=True,
                                        activation=tf.tanh,
-                                       name="doc_ftrs_projection_layer")  # [batch_size, max_group_size, ftr_size]
+                                       name="doc_ftrs_projection_layer")  # [batch_size, max_group_size, 1, ftr_size]
             doc_ftrs = tf.identity(doc_ftrs, name='doc_ftrs_projection')
             num_doc_fields = 1
 
@@ -172,7 +172,7 @@ class RepModel(object):
                                            ftr_size,
                                            use_bias=True,
                                            activation=tf.tanh,
-                                           name="usr_ftrs_projection_layer")  # [batch_size, max_group_size, ftr_size]
+                                           name="usr_ftrs_projection_layer")  # [batch_size, 1, ftr_size]
                 usr_ftrs = tf.identity(usr_ftrs, name='usr_ftrs_projection')
                 num_usr_fields = 1
             else:

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -30,6 +30,10 @@ def add_arguments(parser):
     parser.add_argument("--use_deep", type=str2bool, default=True, help="Whether to use deep features.")
     parser.add_argument("--elem_rescale", type=str2bool, default=True,
                         help="Whether to perform elementwise rescaling.")
+    parser.add_argument("--use_doc_projection", type=str2bool, default=False,
+                        help="whether to project multiple doc features to 1 vector.")
+    parser.add_argument("--use_usr_projection", type=str2bool, default=False,
+                        help="whether to project multiple usr features to 1 vector.")
 
     # Ranking specific
     parser.add_argument("--ltr_loss_fn", type=str, default='pairwise', help="learning-to-rank method.")
@@ -167,6 +171,8 @@ def create_hparams(flags):
         use_deep=flags.use_deep,
         elem_rescale=flags.elem_rescale,
         emb_sim_func=flags.emb_sim_func,
+        use_doc_projection=flags.use_doc_projection,
+        use_usr_projection=flags.use_usr_projection,
         num_classes=flags.num_classes,
         optimizer=flags.optimizer,
         max_gradient_norm=flags.max_gradient_norm,

--- a/src/detext/utils/executor_utils.py
+++ b/src/detext/utils/executor_utils.py
@@ -23,7 +23,7 @@ def get_executor_task_type():
         tf_config_json = json.loads(tf_config)
 
         # Logging the status of current worker/evaluator
-        logging.info("Running with TF_CONFIG: ".format(tf_config_json))
+        logging.info("Running with TF_CONFIG: {}".format(tf_config_json))
         task_type = tf_config_json.get('task', {}).get('type')
         logging.info("=========== Current executor task type: {} ==========".format(task_type))
         return task_type


### PR DESCRIPTION
# Description

Doc or usr representations are computed separately and the interaction features are calculated based on the individual doc/usr fields. Eg., if we have 1 query, n usr fields and m doc fields , the the size of cosine similarity features is (1+n)*m. 

This PR adds the support for projecting the usr embeddings and doc embeddings into 1 usr embeddings and 1 doc embeddings. The resulting cosine similarity features have size (1+1)*1=2 for the previous example. This could potentially reduce the resource needed for pre-computation/similarity score calculation during online serving--we only need to store 1 usr embedding and 1 doc embedding instead of (n+m) embeddings. 

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## List all changes 
Please list all changes in the commit.

* added two flags for controlling whether to do usr/doc projections. Default is false.
* in rep_model before similarity score computation, added the option for projecting the usr/doc fields with a dense layer. The size of the layer equals the individual field representation dim (ftr_size).

# Testing
* added unit test for the projection support
* pytest
* flake8
* tested a full run with detext/resources/run_detext.sh


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
