### PR TITLE
Update logging logic

### DIFF
--- a/src/detext/model/deep_match.py
+++ b/src/detext/model/deep_match.py
@@ -124,7 +124,6 @@ class DeepMatch:
             sim_ftrs = tf.identity(sim_ftrs, name="sim_ftrs")
 
         if hparams.get('ftr_mean') is not None and self._wide_ftrs is not None:
-            print("--- use feature normalization ---")
             ftr_mean = tf.constant(hparams.ftr_mean, dtype=tf.float32)
             ftr_std = tf.constant(hparams.ftr_std, dtype=tf.float32)
             self._wide_ftrs = (self._wide_ftrs - ftr_mean) / ftr_std

--- a/src/detext/resources/run_detext.sh
+++ b/src/detext/resources/run_detext.sh
@@ -3,6 +3,7 @@ PYTHONPATH=../.. python ../run_detext.py \
 --ftr_ext=cnn \
 --feature_names=query,label,wide_ftrs,doc_title \
 --emb_sim_func=inner \
+--elem_rescale=True \
 --learning_rate=0.001 \
 --ltr=softmax \
 --max_len=32 \

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -286,15 +286,13 @@ def main(argv):
 
         misc_utils.save_hparams(hparams.out_dir, hparams)
 
-        # set up logger
-        sys.stdout = logger.Logger(os.path.join(hparams.out_dir, 'logging.txt'))
     else:
         # TODO: move removal/creation to a hadoopShellJob st. it does not reside in distributed training code.
         logging.info("Waiting for chief to remove/create directories.")
         # Wait for dir created form chief
         time.sleep(10)
 
-    if task_type == executor_utils.EVALUATOR:
+    if task_type == executor_utils.EVALUATOR or task_type == executor_utils.LOCAL_MODE:
         # set up logger for evaluator
         sys.stdout = logger.Logger(os.path.join(hparams.out_dir, 'eval_log.txt'))
 

--- a/src/detext/train/optimization.py
+++ b/src/detext/train/optimization.py
@@ -1,5 +1,6 @@
 import re
 import tensorflow as tf
+from os.path import join as path_join
 
 
 def create_optimizer(hparams, loss):
@@ -9,17 +10,18 @@ def create_optimizer(hparams, loss):
     """
     tvars = tf.trainable_variables()
 
-    # Print trainable variables
-    print("# Trainable variables")
-    total_param = 0
-    for param in tvars:
-        if param.name.startswith('bert'):
-            psize = 1
-            for s in param.get_shape():
-                psize *= s
-            total_param += psize
-        print("  %s, %s, %s" % (param.name, str(param.get_shape()), param.op.device))
-    print('total bert parameters:', total_param)
+    # Log trainable variables
+    with tf.gfile.Open(path_join(hparams.out_dir, 'network_structure.txt'), 'w') as fout:
+        fout.write("# Trainable variables\n")
+        total_deep_param = 0
+        for param in tvars:
+            if param.name.startswith(hparams.ftr_ext):
+                psize_bert = 1
+                for s in param.get_shape():
+                    psize_bert *= s
+                total_deep_param += psize_bert
+            fout.write("  %s, %s, %s\n" % (param.name, str(param.get_shape()), param.op.device))
+        fout.write('total {} parameters: {}\n'.format(hparams.ftr_ext, total_deep_param))
 
     # Define optimizer parameters
     init_lr = hparams.learning_rate

--- a/src/detext/train/train.py
+++ b/src/detext/train/train.py
@@ -104,6 +104,7 @@ def train(hparams, input_fn):
         train_spec=train_spec,
         eval_spec=eval_spec
     )
+    print("***** Training finished. *****")
 
     # Evaluation with test set: create an estimator with the best_checkpoint_dir to load the best model
     task_type = executor_utils.get_executor_task_type()
@@ -128,7 +129,7 @@ def train(hparams, input_fn):
                                       cnn_filter_window_size=max(
                                           hparams.filter_window_sizes) if hparams.ftr_ext == 'cnn' else 0)
         )
-        print("\n\n***** Eval results of best model on test data: *****")
+        print("\n***** Evaluation on test set with best exported model: *****")
         for key in sorted(result.keys()):
             print("%s = %s" % (key, str(result[key])))
 

--- a/src/detext/utils/best_checkpoint_copier.py
+++ b/src/detext/utils/best_checkpoint_copier.py
@@ -62,9 +62,7 @@ class BestCheckpointCopier(tf.estimator.Exporter):
         self.pmetric = pmetric
         self.sort_reverse = sort_reverse
         self.eval_log_file = eval_log_file
-        if self.eval_log_file is not None:
-            with tf.gfile.Open(eval_log_file, 'w') as fout:
-                fout.write("***** Evaluation on Dev Set *****\n")
+        self._log("***** Evaluation on dev set during training *****")
         super().__init__()
 
     def _copyCheckpoint(self, checkpoint):
@@ -106,7 +104,7 @@ class BestCheckpointCopier(tf.estimator.Exporter):
         """
         Formatting log.
         """
-        print('[{}] {}'.format(self.__class__.__name__, statement))
+        print(statement)
         if self.eval_log_file is not None:
             with tf.gfile.Open(self.eval_log_file, 'a') as fout:
                 fout.write(statement + '\n')
@@ -134,9 +132,9 @@ class BestCheckpointCopier(tf.estimator.Exporter):
             if metric != self.pmetric and metric != 'global_step':
                 cm = eval_result[metric]
                 if not hasattr(cm, "__len__"):
-                    self._log("## {} : {}".format(metric, cm))
+                    self._log("{} : {}".format(metric, cm))
                 else:
-                    self._log("## {} : ".format(cm))
+                    self._log("{} : ".format(cm))
                     self._log(str(cm))
         return float(eval_result[self.pmetric])
 
@@ -165,4 +163,6 @@ class BestCheckpointCopier(tf.estimator.Exporter):
             tf.estimator.BestExporter._garbage_collect_exports(self, export_path)
         else:
             self._log('skipping checkpoint {} with {} = {}'.format(checkpoint.file, self.pmetric, checkpoint.score))
+        # print new line.
+        self._log('')
         return export_result

--- a/src/detext/utils/executor_utils.py
+++ b/src/detext/utils/executor_utils.py
@@ -23,7 +23,7 @@ def get_executor_task_type():
         tf_config_json = json.loads(tf_config)
 
         # Logging the status of current worker/evaluator
-        logging.info("Running with TF_CONFIG: ".format(tf_config_json))
+        logging.info("Running with TF_CONFIG: {}".format(tf_config_json))
         task_type = tf_config_json.get('task', {}).get('type')
         logging.info("=========== Current executor task type: {} ==========".format(task_type))
         return task_type

--- a/src/detext/utils/misc_utils.py
+++ b/src/detext/utils/misc_utils.py
@@ -329,7 +329,6 @@ def get_input_files(input_patterns):
         if tf.io.gfile.isdir(input_pattern):
             input_pattern = os.path.join(input_pattern, '*')
         input_files.extend(tf.gfile.Glob(input_pattern))
-    print("*** Input Files *** {} {}".format(input_patterns, len(input_files)))
     return input_files
 
 

--- a/src/detext/utils/model_utils.py
+++ b/src/detext/utils/model_utils.py
@@ -7,7 +7,6 @@ def init_word_embedding(hparams, mode, name_prefix="w"):
 
     This function is only used by encoding models other than BERT
     """
-    embedding_name = "{}_embedding".format(name_prefix)
 
     we_trainable = hparams.get("we_trainable")
     we_file = hparams.get("we_file")
@@ -15,13 +14,13 @@ def init_word_embedding(hparams, mode, name_prefix="w"):
     num_units = hparams.get("num_units")
 
     if we_file is None:
+        embedding_name = "{}_pretrained_embedding".format(name_prefix)
         # Random initialization
         embedding = tf.get_variable(
             embedding_name, [vocab_size, num_units], dtype=tf.float32, trainable=we_trainable)
     else:
         # Initialize by pretrained word embedding
-        print('mode=' + str(mode))
-        print('Loading pretrained word embedding from {}'.format(we_file))
+        embedding_name = "{}_embedding".format(name_prefix)
         we = pickle.load(tf.gfile.Open(we_file, 'rb'))
         assert vocab_size == we.shape[0] and num_units == we.shape[1]
         embedding = tf.get_variable(


### PR DESCRIPTION
# Description

Currently DeText logger logs both network structure and evaluation metrics in the following manner:
* For single node training, there's one `logging.txt` that has all logs
* For parameter server (worker + evaluator) training, `logging.txt` logs the network related while `eval_log.txt` logs the evaluation related from the evaluator.

This PR consolidates the logging method and better arranges the logging output:
* Network related (trainable variables, their shapes, and total deep parameters) are logged in `network_structure.txt`
* Evaluation logs will be in `eval_log.txt` for both single node training and ps multi worker training.

Fixes # (issue)
AIAF-365

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


## List all changes 
Please list all changes in the commit.
Removed unnecessary prints
Use `network_structure.txt` file for logging variable related outputs
Removed `logging.txt` as the useful logging is moved to `network_structure.txt`
Tidied eval logging in `best_checkpoint_copier.py`

# Testing
Tested the training flow with `run_detext.sh`. Logging files listed below:
```
$ ls *.txt
eval_log.txt		network_structure.txt
```

```
$ cat eval_log.txt 
***** Evaluation on dev set during training *****
## Step 2
loss : 1.2556911706924438
Checking checkpoint model.ckpt-2
keeping checkpoint model.ckpt-2 with metric/ndcg@10 = 0.7103099226951599

## Step 10
loss : 0.9746564030647278
Checking checkpoint model.ckpt-10
keeping checkpoint model.ckpt-10 with metric/ndcg@10 = 1.0
removing old checkpoint model.ckpt-2 with metric/ndcg@10 = 0.7103099226951599

***** Training finished. *****

***** Evaluation on test set with best exported model: *****
global_step = 10
loss = 0.9746564
metric/ndcg@10 = 1.0
```

```
$ cat network_structure.txt 
# Trainable variables
  w_pretrained_embedding:0, (14, 32), /device:CPU:0
  cnn/query_cnn_3/kernel:0, (3, 32, 1, 50), /device:CPU:0
  cnn/query_cnn_3/bias:0, (50,), /device:CPU:0
  cnn/doc_cnn_0_3/kernel:0, (3, 32, 1, 50), /device:CPU:0
  cnn/doc_cnn_0_3/bias:0, (50,), /device:CPU:0
  wide_ftr_norm_w:0, (10,), /device:CPU:0
  wide_ftr_norm_b:0, (10,), /device:CPU:0
  hidden_projection_0/kernel:0, (11, 100), /device:CPU:0
  hidden_projection_0/bias:0, (100,), /device:CPU:0
  scoring/kernel:0, (100, 1), /device:CPU:0
  scoring/bias:0, (1,), /device:CPU:0
total cnn parameters: 9700
```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
