### PR TITLE
[detext] Fix multi layer runtime crash when using multi-layer LSTM en…

### DIFF
--- a/src/detext/model/lstm_model.py
+++ b/src/detext/model/lstm_model.py
@@ -135,7 +135,7 @@ class LstmModel():
 
         # Whether to use bidirectional RNN
         if hparams.bidirectional:
-            seq_outputs, final_states = tf.nn.bidirectional_dynamic_rnn(
+            _, final_states = tf.nn.bidirectional_dynamic_rnn(
                 self.cell_fw,
                 self.cell_bw,
                 input_emb,
@@ -143,15 +143,21 @@ class LstmModel():
                 sequence_length=seq_len,
                 time_major=False,
                 swap_memory=True)
-            final_h = tf.concat([final_states[0].h, final_states[1].h], axis=1)
+            if hparams.num_layers == 1:
+                final_h = tf.concat([final_states[0].h, final_states[1].h], axis=1)
+            else:
+                final_h = tf.concat([final_states[0][-1].h, final_states[1][-1].h], axis=1)
         else:
-            seq_outputs, final_states = tf.nn.dynamic_rnn(
+            _, final_states = tf.nn.dynamic_rnn(
                 self.cell,
                 input_emb,
                 dtype=self.cell_dtype,
                 sequence_length=seq_len,
                 time_major=False,
                 swap_memory=True)  # [batch_size, seq_len, num_units]
-            final_h = final_states.h
+            if hparams.num_layers == 1:
+                final_h = final_states.h
+            else:
+                final_h = final_states[-1].h
 
         return final_h

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -1,5 +1,5 @@
 """
-Overall pipeline to train the model.  It parses arguments, and trains a CLSM model.
+Overall pipeline to train the model.  It parses arguments, and trains a DeText model.
 """
 
 import sys
@@ -57,8 +57,8 @@ def add_arguments(parser):
     parser.add_argument("--bert_checkpoint", type=str, default=None, help="pretrained bert model checkpoint.")
 
     # LSTM related
-    parser.add_argument("--unit_type", type=str, default="lstm",
-                        help="RNN cell unit type. Support lstm/gru/layer_norm_lstm")
+    parser.add_argument("--unit_type", type=str, default="lstm", choices=["lstm"],
+                        help="RNN cell unit type. Currently only supports lstm. Will support other cell types in the future")
     parser.add_argument("--num_layers", type=int, default=1, help="RNN layers")
     parser.add_argument("--num_residual_layers", type=int, default=0,
                         help="Number of residual layers from top to bottom. For example, if `num_layers=4` and "

--- a/test/model/test_lstm_model.py
+++ b/test/model/test_lstm_model.py
@@ -20,9 +20,13 @@ class TestLstmModel(tf.test.TestCase):
                    [1, 3, 3, 1],
                    [5, 6, 0, 0]]]
 
-    def testLstmLmModelUnnormalized(self):
-        """Test unnormalized_lm LstmLmFtrExt outputs"""
+    def testLstm(self):
+        """Tests LSTM text encoder """
+        for num_layers in [1, 2, 3]:
+            for bidirectional in [True, False]:
+                self._testLstm(num_layers, bidirectional)
 
+    def _testLstm(self, num_layers, bidirectional):
         with tf.Graph().as_default():
             query = tf.constant(self.query, dtype=tf.int32)
             doc_field1 = tf.constant(self.doc_field1, dtype=tf.int32)
@@ -45,12 +49,12 @@ class TestLstmModel(tf.test.TestCase):
                 num_hidden=[0],
                 pad_id=0,
                 unit_type='lstm',
-                num_layers=1,
+                num_layers=num_layers,
                 num_residual_layers=0,
                 forget_bias=0.5,
                 random_seed=11,
                 rnn_dropout=0.,
-                bidirectional=True,
+                bidirectional=bidirectional,
             )
 
             model = lstm_model.LstmModel(query,


### PR DESCRIPTION
…coder

# Description

When using num_layers > 1 for ftr_ext=lstm, training crashes because incorrect calls for LSTM state (there's no `LstmStateTuple.h` when num_layers > 1, we have to call `LstmStateTuple[-1].h`). This PR fixes such issue.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## List all changes 
Please list all changes in the commit.
* Fix bugs in lstm_model.py
* Add more unit tests regarding bidirectional and num_layers in test_lstm_model
* Limit the choice of unit_type of lstm because current implementation only works for LSTM cell

# Testing
* Unit tests in test_lstm_model. These tests test for shape and thus guarantee a smooth run

**Test Configuration**:
# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
