### PR TITLE
Remove BestCheckpointCopier logging file in hvd

### DIFF
--- a/src/detext/train/train.py
+++ b/src/detext/train/train.py
@@ -19,7 +19,6 @@ def train(hparams, input_fn):
     :param input_fn: input function to create train/eval specs
     :return:
     """
-    eval_log_file = None
     if hparams.use_horovod is True:
         import horovod.tensorflow as hvd
     train_strategy = tf.contrib.distribute.ParameterServerStrategy()

--- a/src/detext/train/train.py
+++ b/src/detext/train/train.py
@@ -22,7 +22,6 @@ def train(hparams, input_fn):
     eval_log_file = None
     if hparams.use_horovod is True:
         import horovod.tensorflow as hvd
-        eval_log_file = path_join(hparams.out_dir, 'eval_log.txt')
     train_strategy = tf.contrib.distribute.ParameterServerStrategy()
     estimator = get_estimator(hparams, strategy=train_strategy)
 
@@ -39,8 +38,7 @@ def train(hparams, input_fn):
             exports_to_keep=1,  # keeping the best savedmodel
             pmetric='metric/{}'.format(hparams.pmetric),
             compare_fn=lambda x, y: x.score > y.score,  # larger metric better
-            sort_reverse=True,
-            eval_log_file=eval_log_file)
+            sort_reverse=True)
         exporter_list = [best_checkpoint_exporter]
 
     # Handle sync distributed training case via use_horovod


### PR DESCRIPTION
Fixing logging error in hvd training.

# Description

Remove the logging file and in hvd training, we can create the logging file similar to local mode.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## List all changes 
Removed the eval_log for BestCheckpointCopier when using hvd, similar to when not using.

# Testing
Local test


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
