### PR TITLE
A quick fix to remove non-cnn filter logic in misc_utils.py which bre…

### DIFF
--- a/src/detext/resources/run_detext.sh
+++ b/src/detext/resources/run_detext.sh
@@ -2,13 +2,13 @@
 PYTHONPATH=../.. python ../run_detext.py \
 --ftr_ext cnn \
 --feature_names query,label,wide_ftrs,doc_title,usr_headline,wide_ftrs_sp_idx,wide_ftrs_sp_val \
---emb_sim_func inner \
+--emb_sim_func inner concat diff \
 --elem_rescale True \
 --learning_rate 0.001 \
 --ltr softmax \
 --max_len 32 \
 --min_len 3 \
---filter_window_sizes 3 \
+--filter_window_sizes 1 2 3 \
 --num_filters 50 \
 --num_hidden 100 \
 --num_train_steps 10 \
@@ -18,6 +18,7 @@ PYTHONPATH=../.. python ../run_detext.py \
 --sp_emb_size 10 \
 --optimizer bert_adam \
 --pmetric ndcg@10 \
+--all_metrics ndcg@10 precision@1 \
 --random_seed 11 \
 --steps_per_stats 1 \
 --steps_per_eval 2 \

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -46,7 +46,7 @@ class Args(NamedTuple):
     # Ranking specific
     ltr_loss_fn: str = 'pairwise'  # learning-to-rank method.
     emb_sim_func: List[str] = ['inner']  # Approach to computing query/doc similarity scores
-    _emb_sim_func = {"choices": ('inner', 'hadamard', 'concat')}
+    _emb_sim_func = {"choices": ('inner', 'hadamard', 'concat', 'diff')}
 
     # Classification specific
     num_classes: int = 1  # Number of classes for multi-class classification tasks.

--- a/src/detext/utils/misc_utils.py
+++ b/src/detext/utils/misc_utils.py
@@ -99,10 +99,6 @@ def extend_hparams(hparams):
     tok2regex_pattern = {'plain': None, 'punct': r'(\pP)'}
     hparams.regex_replace_pattern = tok2regex_pattern[hparams.tokenization]
 
-    # if bert, then disable cnn parameters
-    if hparams.ftr_ext != 'cnn':
-        hparams.filter_window_sizes = '0'
-
     assert hparams.pmetric is not None, "Please set your primary evaluation metric using --pmetric option"
     assert hparams.pmetric != 'confusion_matrix', 'confusion_matrix cannot be used as primary evaluation metric.'
 


### PR DESCRIPTION

# Description
Fixed a bug introduced in PR #25 related to the CNN filter window size. Without this fix, the argument parsing will fail for non-CNN models.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## List all changes 
Please list all changes in the commit.
* Removed the non-cnn filter logic in `misc_utils.py`
* Updated the parameters in `run_detext.sh`

# Testing
flake8 for styles
pytest for unit test
sh run_detext.sh
sh run_detext_multitask.sh

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
