### PR TITLE
expose bert dropout option

### DIFF
--- a/src/detext/model/bert_model.py
+++ b/src/detext/model/bert_model.py
@@ -113,16 +113,18 @@ class BertModel(object):
         # 2. apply bert
         self.text_ftr_size = hparams.num_units
 
+        is_training = self.mode == tf.estimator.ModeKeys.TRAIN
+
         bertm = create_bert_model(
             bert_config_path=hparams.bert_config_file,
-            is_training=False,
+            is_training=(is_training and hparams.use_bert_dropout),
             input_ids=self.bert_input_ids,
             input_mask=self.bert_input_mask,
             use_one_hot_embeddings=False
         )
 
         # initialize bert with pretrained checkpoint
-        if self.mode == tf.estimator.ModeKeys.TRAIN and self.hparams.bert_checkpoint is not None:
+        if is_training and self.hparams.bert_checkpoint is not None:
             init_from_checkpoint(self.hparams.bert_checkpoint)
 
         # 3. get query embedding and doc_fields embedding
@@ -135,7 +137,7 @@ class BertModel(object):
         )  # shape = [# of texts, bert_dim]
 
         # dropout
-        if self.mode == tf.estimator.ModeKeys.TRAIN:
+        if is_training:
             pooled_output = tf.nn.dropout(pooled_output, keep_prob=0.9)
 
         # Get query features

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -60,6 +60,7 @@ class Args(NamedTuple):
     lr_bert: float = None  # Learning rate factor for bert components
     bert_config_file: str = None  # bert config.
     bert_checkpoint: str = None  # pretrained bert model checkpoint.
+    use_bert_dropout: bool = False  # apply dropout during training in bert layers.
 
     # LSTM related
     unit_type: str = 'lstm'  # RNN cell unit type. Currently only supports lstm. Will support other cell types in the future

--- a/test/test_run_detext.py
+++ b/test/test_run_detext.py
@@ -11,6 +11,7 @@ out_dir = os.path.join(root_dir, "output")
 data = os.path.join(root_dir, "train", "dataset", "tfrecord")
 multitask_data = os.path.join(root_dir, "train", "multitask", "tfrecord")
 vocab = os.path.join(root_dir, "vocab.txt")
+bert_config = os.path.join(root_dir, "bert_config.json")
 
 
 class TestModel(tf.test.TestCase):
@@ -75,16 +76,30 @@ class TestModel(tf.test.TestCase):
         main(sys.argv)
         self._cleanUp(output)
 
-    def test_run_detext_non_cnn(self):
+    def test_run_detext_lstm(self):
         """
-        This method test run_detext with non-CNN models
+        This method test run_detext with LSTM models
         """
-        output = os.path.join(out_dir, "non_cnn_model")
+        output = os.path.join(out_dir, "lstm")
         args = self.args + \
             ["--filter_window_size", "0",
              "--ftr_ext", "lstm",
              "--num_hidden", "10",
              "--out_dir", output]
+        sys.argv[1:] = args
+        main(sys.argv)
+        self._cleanUp(output)
+
+    def test_run_detext_bert(self):
+        """
+        This method test run_detext with BERT models
+        """
+        output = os.path.join(out_dir, "bert")
+        args = self.args + \
+               ["--ftr_ext", "bert",
+                "--bert_config_file", bert_config,
+                "--use_bert_dropout", "True",
+                "--out_dir", output]
         sys.argv[1:] = args
         main(sys.argv)
         self._cleanUp(output)

--- a/test/test_run_detext.py
+++ b/test/test_run_detext.py
@@ -96,10 +96,10 @@ class TestModel(tf.test.TestCase):
         """
         output = os.path.join(out_dir, "bert")
         args = self.args + \
-               ["--ftr_ext", "bert",
-                "--bert_config_file", bert_config,
-                "--use_bert_dropout", "True",
-                "--out_dir", output]
+            ["--ftr_ext", "bert",
+             "--bert_config_file", bert_config,
+             "--use_bert_dropout", "True",
+             "--out_dir", output]
         sys.argv[1:] = args
         main(sys.argv)
         self._cleanUp(output)


### PR DESCRIPTION
# Description

This pr add a param to control whether to apply dropouts in the attention and hidden layers in Bert. Previously the dropouts are not applied.

Fixes # (issue)


Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## List all changes 
Please list all changes in the commit.

Added param `use_bert_dropout` to control this behavior, defaults to False to keep the same default behavior 
Modified logic in `bert_model`
Added a Bert test in `test_run_detext.py`

# Testing

local test


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
