### PR TITLE
add option to add dimension to query/usr placeholders for online serving

### DIFF
--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -123,6 +123,8 @@ class Args(NamedTuple):
     pmetric: str = None  # Primary metric.
     all_metrics: List[str] = None  # All metrics.
     score_rescale: List[float] = None  # The mean and std of previous model. For score rescaling, the score_rescale has the xgboost mean and std.
+    add_first_dim_for_query_placeholder: bool = False  # Whether to add a batch dimension for query and usr_* placeholders. This shall be set to True if the query field is used as document feature in model serving.
+    add_first_dim_for_usr_placeholder: bool = False  # Whether to add a batch dimension for query and usr_* placeholders. This shall be set to True if usr fields are used document feature in model serving.
 
     tokenization: str = 'punct'  # The tokenzation performed for data preprocessing. Currently support: punct/plain(no split). Note that this should be set correctly to ensure consistency for savedmodel.# noqa: E501
     _tokenization = {'choices': ['plain', 'punct']}

--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -123,8 +123,9 @@ class Args(NamedTuple):
     pmetric: str = None  # Primary metric.
     all_metrics: List[str] = None  # All metrics.
     score_rescale: List[float] = None  # The mean and std of previous model. For score rescaling, the score_rescale has the xgboost mean and std.
-    add_first_dim_for_query_placeholder: bool = False  # Whether to add a batch dimension for query and usr_* placeholders. This shall be set to True if the query field is used as document feature in model serving.
-    add_first_dim_for_usr_placeholder: bool = False  # Whether to add a batch dimension for query and usr_* placeholders. This shall be set to True if usr fields are used document feature in model serving.
+
+    add_first_dim_for_query_placeholder: bool = False  # Whether to add a batch dimension for query and usr_* placeholders. This shall be set to True if the query field is used as document feature in model serving.# noqa: E501
+    add_first_dim_for_usr_placeholder: bool = False  # Whether to add a batch dimension for query and usr_* placeholders. This shall be set to True if usr fields are used document feature in model serving.# noqa: E501
 
     tokenization: str = 'punct'  # The tokenzation performed for data preprocessing. Currently support: punct/plain(no split). Note that this should be set correctly to ensure consistency for savedmodel.# noqa: E501
     _tokenization = {'choices': ['plain', 'punct']}

--- a/src/detext/train/train.py
+++ b/src/detext/train/train.py
@@ -145,15 +145,15 @@ def serving_input_fn(hparams):
     # Define placeholders and features
     doc_feature_names = [df for df in hparams.feature_names if df.startswith('doc_')]
     usr_feature_names = [df for df in hparams.feature_names if df.startswith('usr_')]
-    doc_fields, doc_placeholders = train_helper.get_doc_fields(hparams, hparams.regex_replace_pattern)
-    usr_fields, usr_placeholders = train_helper.get_usr_fields(hparams, hparams.regex_replace_pattern)
+    doc_fields, doc_placeholders = train_helper.get_doc_fields(hparams)
+    usr_fields, usr_placeholders = train_helper.get_usr_fields(hparams)
 
     doc_id_feature_names = [df for df in hparams.feature_names if df.startswith('docId_')]
     usr_id_feature_names = [df for df in hparams.feature_names if df.startswith('usrId_')]
     doc_id_fields, doc_id_placeholders = train_helper.get_doc_id_fields(hparams)
     usr_id_fields, usr_id_placeholders = train_helper.get_usr_id_fields(hparams)
 
-    query, query_placeholder = train_helper.get_query(hparams, hparams.regex_replace_pattern)
+    query, query_placeholder = train_helper.get_query(hparams)
     wide_ftr_placeholder, wide_ftrs = train_helper.create_placeholder_for_ftrs(
         "wide_ftr_placeholder", [None, hparams.num_wide], tf.float32, 'wide_ftrs', hparams.feature_names)
     wide_ftr_sp_idx_placeholder, wide_ftrs_sp_idx = train_helper.create_placeholder_for_ftrs(

--- a/test/resources/run_detext.sh
+++ b/test/resources/run_detext.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-PYTHONPATH=../.. python ../../src/detext/run_detext.py \
+PYTHONPATH=../../src python ../../src/detext/run_detext.py \
 --ftr_ext cnn \
 --feature_names query,label,wide_ftrs,doc_title,usr_headline,wide_ftrs_sp_idx,wide_ftrs_sp_val \
 --emb_sim_func inner concat diff \
@@ -31,3 +31,5 @@ PYTHONPATH=../.. python ../../src/detext/run_detext.py \
 --train_file sample_data/hc_examples.tfrecord \
 --vocab_file vocab.txt \
 --out_dir /tmp/detext-output/hc_cnn_f50_u32_h100 \
+--add_first_dim_for_query_placeholder True \
+--add_first_dim_for_usr_placeholder True


### PR DESCRIPTION
# Description

In the model serving (internal), we require the features to have at least 1 dimension (batch size) if used as document features. Currently we have multiple use cases of such and have to manually add a dimension to query and usr fields. This RB expose two params to control whether to add dimension to these placeholders.

Fixes # (issue)

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## List all changes 
- Added option `add_first_dim_for_query_placeholder` and `add_first_dim_for_usr_placeholder` for query and usr features respectively. 
- In `train_helper.py`, `get_query`, if `add_first_dim_for_query_placeholder` is True, then the placeholder created will have shape [None] instead of []. The placeholder is then squeezed internally to work with rest of the graph. Similar logic added in `get_usr_fields`
- Refactored input signatures for `get_query`, `get_doc_fields`, and `get_usr_fields`.
- Fixed `run_detext.sh` PYTHONPATH

# Testing
Tested with  `run_detext.sh` and inspected the output:
With `add_first_dim_for_query_placeholder=True` and `add_first_dim_for_usr_placeholder=True`, the signatures are:
```
The given SavedModel SignatureDef contains the following input(s):
  inputs['doc_title'] tensor_info:
      dtype: DT_STRING
      shape: (-1)
      name: doc_title_placeholder:0
  inputs['label'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1)
      name: label_placeholder:0
  inputs['query'] tensor_info:
      dtype: DT_STRING
      shape: (-1)
      name: query_placeholder:0
  inputs['uid'] tensor_info:
      dtype: DT_INT64
      shape: ()
      name: uid_placeholder:0
  inputs['usr_headline'] tensor_info:
      dtype: DT_STRING
      shape: (-1)
      name: usr_headline_placeholder:0
  inputs['weight'] tensor_info:
      dtype: DT_FLOAT
      shape: ()
      name: weight_placeholder:0
  inputs['wide_ftrs'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1, 2)
      name: wide_ftr_placeholder:0
  inputs['wide_ftrs_sp_idx'] tensor_info:
      dtype: DT_INT32
      shape: (-1, -1)
      name: wide_ftr_sp_idx_placeholder:0
  inputs['wide_ftrs_sp_val'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1, -1)
      name: wide_ftr_sp_val_placeholder:0
The given SavedModel SignatureDef contains the following output(s):
  outputs['label'] tensor_info:
      dtype: DT_FLOAT
      shape: (1, -1)
      name: ExpandDims_6:0
  outputs['scores'] tensor_info:
      dtype: DT_FLOAT
      shape: (1, -1)
      name: Squeeze_2:0
  outputs['uid'] tensor_info:
      dtype: DT_INT64
      shape: (1)
      name: Const_9:0
  outputs['weight'] tensor_info:
      dtype: DT_FLOAT
      shape: (1)
      name: Const_10:0
```
With `add_first_dim_for_query_placeholder=False` and `add_first_dim_for_usr_placeholder=False` (this is the default, and same as before), the signatures are:
```
The given SavedModel SignatureDef contains the following input(s):
  inputs['doc_title'] tensor_info:
      dtype: DT_STRING
      shape: (-1)
      name: doc_title_placeholder:0
  inputs['label'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1)
      name: label_placeholder:0
  inputs['query'] tensor_info:
      dtype: DT_STRING
      shape: ()
      name: query_placeholder:0
  inputs['uid'] tensor_info:
      dtype: DT_INT64
      shape: ()
      name: uid_placeholder:0
  inputs['usr_headline'] tensor_info:
      dtype: DT_STRING
      shape: ()
      name: usr_headline_placeholder:0
  inputs['weight'] tensor_info:
      dtype: DT_FLOAT
      shape: ()
      name: weight_placeholder:0
  inputs['wide_ftrs'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1, 2)
      name: wide_ftr_placeholder:0
  inputs['wide_ftrs_sp_idx'] tensor_info:
      dtype: DT_INT32
      shape: (-1, -1)
      name: wide_ftr_sp_idx_placeholder:0
  inputs['wide_ftrs_sp_val'] tensor_info:
      dtype: DT_FLOAT
      shape: (-1, -1)
      name: wide_ftr_sp_val_placeholder:0
The given SavedModel SignatureDef contains the following output(s):
  outputs['label'] tensor_info:
      dtype: DT_FLOAT
      shape: (1, -1)
      name: ExpandDims_6:0
  outputs['scores'] tensor_info:
      dtype: DT_FLOAT
      shape: (1, -1)
      name: Squeeze:0
  outputs['uid'] tensor_info:
      dtype: DT_INT64
      shape: (1)
      name: Const_9:0
  outputs['weight'] tensor_info:
      dtype: DT_FLOAT
      shape: (1)
      name: Const_10:0
Method name is: tensorflow/serving/predict
```

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
