### PR TITLE
Make DeText py36 compatible; add py36 automatic build workflow

### DIFF
--- a/.github/workflows/python-app-py36.yml
+++ b/.github/workflows/python-app-py36.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python application
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.6
+    - name: Install dependencies
+      run: |
+        python setup.py develop
+    - name: Lint with flake8
+      run: |
+        pip install flake8
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --ignore=E121,E123,E226,W292,E402 --max-line-length=160 --exclude=src/detext/model/bert/*.py --show-source --statistics
+    - name: Test with pytest
+      run: |
+        pip install pytest
+        pytest

--- a/.github/workflows/python-app-py36.yml
+++ b/.github/workflows/python-app-py36.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Python 3.6 application
 
 on:
   push:

--- a/.github/workflows/python-app-py37.yml
+++ b/.github/workflows/python-app-py37.yml
@@ -1,7 +1,7 @@
 # This workflow will install Python dependencies, run tests and lint with a single version of Python
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
 
-name: Python application
+name: Python 3.7 application
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Python application](https://github.com/linkedin/detext/workflows/Python%20application/badge.svg)  ![tensorflow](https://img.shields.io/badge/tensorflow-1.14.0-green.svg) ![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)
+![Python 3.6 application](https://github.com/linkedin/detext/workflows/Python%203.6%20application/badge.svg) ![Python 3.7 application](https://github.com/linkedin/detext/workflows/Python%203.7%20application/badge.svg)  ![tensorflow](https://img.shields.io/badge/tensorflow-1.14.0-green.svg) ![License](https://img.shields.io/badge/License-BSD%202--Clause-orange.svg)
 
 DeText: A Deep Neural Ranking Framework with Text Understanding
 ========

--- a/src/arg_suite/arg_suite.py
+++ b/src/arg_suite/arg_suite.py
@@ -205,7 +205,7 @@ class ArgSuite(Generic[ArgType]):
         logger.info(f"{argv} is parsed to {ns}")
         kwargs = {
             attr: get_origin(self._arg_class._field_types[attr])(value)
-            if isinstance(value, List) else value
+            if isinstance(value, List) and get_origin(self._arg_class._field_types[attr]) != List else value
             for attr, value in vars(ns).items()
         }
         return self._arg_class(**kwargs)


### PR DESCRIPTION
# Description

Change for arg_suite to work with py36.
Add github workflow for automatically testing py36. Rename workflow files. 

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

## List all changes 
add check argument in arg parsing
added py36 workflow
renamed py37 workflow and updated badges in README.md

# Testing
workflow tests run ok under both py36 and py37


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
