### PR TITLE
fix text preprocessing for inference model

### DIFF
--- a/src/detext/train/train_helper.py
+++ b/src/detext/train/train_helper.py
@@ -43,7 +43,7 @@ def get_query(hparams):
             hparams.CLS, hparams.SEP, hparams.PAD,
             hparams.max_len,
             hparams.min_len,
-            cnn_filter_window_size=max(hparams.filter_window_sizes)
+            cnn_filter_window_size=max(hparams.filter_window_sizes) if hparams.ftr_ext == 'cnn' else 0
         )
     return query, query_placeholder
 
@@ -75,7 +75,7 @@ def get_doc_fields(hparams):
                 hparams.CLS, hparams.SEP, hparams.PAD,
                 hparams.max_len,
                 hparams.min_len,
-                cnn_filter_window_size=max(hparams.filter_window_sizes)
+                cnn_filter_window_size=max(hparams.filter_window_sizes) if hparams.ftr_ext == 'cnn' else 0
             )
             one_doc_field = tf.expand_dims(one_doc_field, axis=0)
             doc_fields.append(one_doc_field)
@@ -118,7 +118,7 @@ def get_usr_fields(hparams):
                 hparams.CLS, hparams.SEP, hparams.PAD,
                 hparams.max_len,
                 hparams.min_len,
-                cnn_filter_window_size=max(hparams.filter_window_sizes)
+                cnn_filter_window_size=max(hparams.filter_window_sizes) if hparams.ftr_ext == 'cnn' else 0
             )
             usr_fields.append(one_usr_field)
     return usr_fields, usr_text_placeholders

--- a/src/detext/utils/misc_utils.py
+++ b/src/detext/utils/misc_utils.py
@@ -99,6 +99,10 @@ def extend_hparams(hparams):
     tok2regex_pattern = {'plain': None, 'punct': r'(\pP)'}
     hparams.regex_replace_pattern = tok2regex_pattern[hparams.tokenization]
 
+    # if not using cnn models, then disable cnn parameters
+    if hparams.ftr_ext != 'cnn':
+        hparams.filter_window_sizes = [0]
+
     assert hparams.pmetric is not None, "Please set your primary evaluation metric using --pmetric option"
     assert hparams.pmetric != 'confusion_matrix', 'confusion_matrix cannot be used as primary evaluation metric.'
 


### PR DESCRIPTION
# Description

In https://github.com/linkedin/detext/pull/28 the `filter_window_sizes` override was removed. The param passing to `process_text` is inconsistent for none-CNN models:

* `process_text`: https://github.com/linkedin/detext/blob/master/src/detext/train/data_fn.py#L151
* training call (correct): https://github.com/linkedin/detext/blob/master/src/detext/train/train.py#L60
* inference model call (incorrect after #28 ): https://github.com/linkedin/detext/blob/master/src/detext/train/train_helper.py#L121

This inconsistency causes problems with the inference savedmodel models. 

This pr fixes the logic for `filter_window_sizes` in the `serving_input_fn`.

Fixes # (issue) 474: internal issue reported for inference model 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## List all changes 
Update logic in train_helper, where the helper functions are used in `serving_input_fn`. This sets the `filter_window_sizes` for cnn only.
Code search on this logic

# Testing
pytest
local training run, and tested inference model.


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
