### PR TITLE
change pypi package to detext-nodep for releases with no dependencies; version bump

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.0.8
+current_version = 2.0.9
 commit = True
 tag = True
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,10 +48,7 @@ The `.bumpversion.cfg` is the single source of truth for versioning DeText. You 
 ### Step 2: merge version changes
 Running the releasing script automatically creates a new commit that includes the version update and a new tag. 
 
-You can verify the new releases at https://pypi.org/project/detext/ and https://pypi.org/project/li-detext/. If the packages are successfully published, create a PR and merge to master.
-
-
-You can verify the release upload at https://pypi.org/project/detext/ and https://pypi.org/project/li-detext/
+You can verify the new releases at https://pypi.org/project/detext/ and https://pypi.org/project/detext-nodep/. If the packages are successfully published, create a PR and merge to master.
 
 
 ### Step 3: add a Tag

--- a/pypi_release.sh
+++ b/pypi_release.sh
@@ -42,7 +42,7 @@ echo "******** Preparing pypi package without dependencies..."
 # Temporarily save setup.py for recover
 cp setup.py setup.py.tmp
 # Rename the pypi package name
-sed -i "" "s/name='detext'/name='li-detext'/" setup.py
+sed -i "" "s/name='detext'/name='detext-nodep'/" setup.py
 # Remove install_requires entries
 sed -i "" "s/install_requires=\[.*\]/install_requires=[]/g" setup.py
 python setup.py sdist

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setuptools.setup(
                  "License :: OSI Approved"],
     license='BSD-2-CLAUSE',
     # DO NOT CHANGE: version should be incremented by bump2version when releasing. See pypi_release.sh
-    version='2.0.8',
+    version='2.0.9',
     package_dir={'': 'src'},
     packages=setuptools.find_packages('src'),
     include_package_data=True,


### PR DESCRIPTION
# Description

In order to avoid confusions with li internal repo name, changing the pypi package to `detext-nodep` from `li-detext`. Also bumped version for release.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## List all changes 
Refactored the pypi names in code and readme files
Bumped patch version
Deprecated the li-detext pypi package

# Testing
ELR'ed and can be imported successfully 


**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
