### PR TITLE
Add run_detext() method back for better encapsulation

### DIFF
--- a/src/detext/run_detext.py
+++ b/src/detext/run_detext.py
@@ -43,6 +43,11 @@ def main(argv):
     """
 
     argument = DetextArg.__from_argv__(argv[1:], error_on_unknown=False)
+    run_detext(argument)
+
+
+def run_detext(argument):
+    """ Launches DeText training program"""
     logging.set_verbosity(logging.INFO)
     logging.info(f"Args:\n {argument}")
 


### PR DESCRIPTION
# Description

Latest GDMix pulling in DeText is failling due to deprecation of this method. This PR adds it back
